### PR TITLE
Add `remove(int)` functionality to clear long running tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ asyncTask.repeat(yourCallbackFunction, 2000);  // Run the callback every 2000 ms
 ```
 
 ### 5. Running the Task Scheduler
-In the `loop()` function, call `asyncTask.run()` to let the scheduler execute any pending tasks:
+In the `loop()` function, call `asyncTask.loop()` to let the scheduler execute any pending tasks:
 
 ```cpp
 void loop() {
-  asyncTask.run();  // Continuously check and run tasks
+  asyncTask.loop();  // Continuously check and run tasks
 }
 ```
 
@@ -87,6 +87,8 @@ Here's an example of using AsyncTask in a sketch:
 
 AsyncTask asyncTask;
 
+unsigned int repeatId;
+
 void setup() {
   Serial.begin(9600);
 
@@ -94,12 +96,17 @@ void setup() {
   asyncTask.once(taskOne, 1000);
 
   // Run this task every 2 seconds
-  asyncTask.repeat(taskTwo, 2000);
+  repeatId = asyncTask.repeat(taskTwo, 2000);
 
   // Run this anonymous task once after 3 second
   asyncTask.once([]() {
     Serial.println("i'm anonymous function task");
   }, 3000);
+
+  asyncTask.once([]() {
+    Serial.println("Task Two stopped!");
+    asyncTask.remove(repeatId);
+  }, 10000);
 }
 
 void loop() {
@@ -125,19 +132,24 @@ asyncTask.clearAllTasks();
 
 
 ### API Reference
-  `void once(Callback callback, unsigned long timeout)`
+  `unsigned int once(Callback callback, unsigned long timeout)`
   - Description: Adds a task that runs once after the specified time.
   - Parameters:
     - `callback`: The function to call when the task runs.
     - `interval`: The time delay (in milliseconds) before the task is executed.
 
- `void repeat(Callback callback, unsigned long interval)`
+ `unsigned int repeat(Callback callback, unsigned long interval)`
   - Description: Adds a task that runs repeatedly at the specified time interval.
   - Parameters:
     - `callback`: The function to call when the task runs.
     - `interval`: The interval (in milliseconds) between each execution of the task.
 
- `void run()`
+ `void remove(unsigned int id)`
+  - Description: Removes a task from execution queue by using its identifier.
+  - Parameters:
+    - `id`: The task id.
+
+ `void loop()`
   - Description: Checks all scheduled tasks and executes any that are due to run. This method should be called frequently in the loop() to ensure that tasks are executed on time.
 
  `void clearAllTasks()`

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -2,6 +2,8 @@
 
 AsyncTask asyncTask;
 
+unsigned int repeatId;
+
 void setup() {
   Serial.begin(9600);
 
@@ -9,12 +11,17 @@ void setup() {
   asyncTask.once(taskOne, 1000);
 
   // Run this task every 2 seconds
-  asyncTask.repeat(taskTwo, 2000);
+  repeatId = asyncTask.repeat(taskTwo, 2000);
 
   // Run this anonymous task once after 3 second
   asyncTask.once([]() {
     Serial.println("i'm anonymous function task");
   }, 3000);
+
+  asyncTask.once([]() {
+    Serial.println("Task Two stopped!");
+    asyncTask.remove(repeatId);
+  }, 10000);
 }
 
 void loop() {

--- a/src/AsyncTask.cpp
+++ b/src/AsyncTask.cpp
@@ -9,17 +9,17 @@ AsyncTask::AsyncTask() {
 }
 
 // Method to add a one-time task
-void AsyncTask::once(Callback callback, unsigned long timeout) {
-  this->addTask(callback, ONCE, timeout);
+unsigned int AsyncTask::once(Callback callback, unsigned long timeout) {
+  return this->addTask(callback, ONCE, timeout);
 }
 
 // Method to add a repeating task
-void AsyncTask::repeat(Callback callback, unsigned long interval) {
-  this->addTask(callback, REPEAT, interval);
+unsigned int AsyncTask::repeat(Callback callback, unsigned long interval) {
+  return this->addTask(callback, REPEAT, interval);
 }
 
 // Private method to add a task with auto-generated ID
-void AsyncTask::addTask(Callback callback, TaskMode mode, unsigned long interval) {
+unsigned int AsyncTask::addTask(Callback callback, TaskMode mode, unsigned long interval) {
   Task *newTask = new Task();
   newTask->id = nextId++;  // Assign and increment the ID
   newTask->callback = callback;
@@ -38,10 +38,11 @@ void AsyncTask::addTask(Callback callback, TaskMode mode, unsigned long interval
     // Set the new task as the next of the last task
     current->next = newTask;
   }
+  return newTask->id;
 }
 
 // Method to remove a task by id
-void AsyncTask::removeTask(int id) {
+void AsyncTask::remove(unsigned int id) {
   Task *current = this->taskList;
   Task *previous = nullptr;
 
@@ -75,7 +76,7 @@ void AsyncTask::loop() {
       if (current->mode == ONCE) {
         Task *toDelete = current;
         current = current->next;         // Move to next task
-        this->removeTask(toDelete->id);  // Remove the task
+        this->remove(toDelete->id);  // Remove the task
       } else {
         current = current->next;  // Move to next task
       }
@@ -88,6 +89,6 @@ void AsyncTask::loop() {
 // A method to clear all tasks (e.g., during cleanup)
 void AsyncTask::clearAllTasks() {
   while (taskList != nullptr) {
-    this->removeTask(taskList->id);
+    this->remove(taskList->id);
   }
 }

--- a/src/AsyncTask.cpp
+++ b/src/AsyncTask.cpp
@@ -24,7 +24,7 @@ unsigned int AsyncTask::addTask(Callback callback, TaskMode mode, unsigned long 
   newTask->id = nextId++;  // Assign and increment the ID
   newTask->callback = callback;
   newTask->mode = mode;
-  newTask->lastRun = 0;
+  newTask->lastRun = millis();
   newTask->interval = interval;
   newTask->next = nullptr;
   if (this->taskList ==

--- a/src/AsyncTask.h
+++ b/src/AsyncTask.h
@@ -8,7 +8,7 @@ class AsyncTask {
 
   // Struct for a single task
   struct Task {
-    int id;                  // Unique task ID
+    unsigned int id;         // Unique task ID
     void (*callback)();      // Pointer to a function
     TaskMode mode;           // Task mode: ONCE or REPEAT
     unsigned long lastRun;   // Timestamp of the last execution
@@ -21,24 +21,24 @@ class AsyncTask {
 
   Task* taskList;             // Head of the linked list
   unsigned long currentTime;  // Current time for task management
-  int nextId;                 // Auto-incrementing task ID
+  unsigned int nextId;        // Auto-incrementing task ID
 
   // Private method to add a task with auto-generated ID
-  void addTask(Callback callback, TaskMode mode, unsigned long interval);
-
-  // Method to remove a task by id (used internally)
-  void removeTask(int id);
+  unsigned int addTask(Callback callback, TaskMode mode, unsigned long interval);
 
  public:
   // Constructor
   AsyncTask();
 
   // Method to add a one-time task
-  void once(Callback callback, unsigned long timeout);
+  unsigned int once(Callback callback, unsigned long timeout);
 
   // Method to add a repeating task
-  void repeat(Callback callback, unsigned long interval);
+  unsigned int repeat(Callback callback, unsigned long interval);
 
+  // Method to remove a task by id
+  void remove(unsigned int id);
+ 
   // Method to be put inside sketch loop 
   void loop();
 


### PR DESCRIPTION
Hiya Moin 👋 . 

I've been using your library on an arduino-clone AVR project I started recently. Thanks for making it available.

While applying the async/scheduled tasks to my code I realized that there was some functionality missing that I needed. The ability to cancel long-running tasks. 

So I exposed `remove(int taskId)` (previously private method `removeTask(int taskId)`) to allow cancelling existing tasks by id (wether its repeated task or otherwise). And also added the ability to return `int` task ids at creation time (using `once()` or `repeat()` methods) so they could be cancelled later.

I also changed the `taskId` type from `int` to `unsigned int` to make all task Ids positive. This is probably not critical since without the change the `taskId++` will just wrap-around due to overflow when you hit 32K and start asigning negative task Ids. But it makes things a bit easier to understand and use, specially for logging purposes. 

I thought I'd let you know about my changes and give you a chance to merge them upstream if you think them useful. There is also a couple of corrections to the README to reflect the above, as well as the use of `.loop()` instead of `.run()` which was incorrect originally.

Kind Regards,
Steven